### PR TITLE
Enable built-in OAuth onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This is a private plugin not available in the Community Plugins catalog. Install
 3. Set your **OAuth Redirect URI** (your deployed callback page URL)
 4. Click **"Connect to Google Drive"**
 5. Complete the OAuth flow in your browser
+6. *(Optional)* Paste **SimpleToken CLI** output into the import area if you prefer using pre-generated tokens instead of the built-in flow.
 
 ### 2. Drive Folder Setup
 


### PR DESCRIPTION
## Summary
- add OAuth client configuration settings, connection status UI, and SimpleToken import guidance so the plugin can launch Google consent directly from Obsidian
- extend the token manager to persist client metadata, handle manual OAuth callbacks, and refresh tokens with optional client secrets
- initialize OAuth from saved settings, surface callback success in the settings tab, and update documentation to reflect the in-app onboarding option

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca6adcba34832aac684f976d5d3cff